### PR TITLE
De-record `Technique.java` to allow for easier extension

### DIFF
--- a/src/main/java/com/cultivation_mod/items/TechniqueBook.java
+++ b/src/main/java/com/cultivation_mod/items/TechniqueBook.java
@@ -26,10 +26,10 @@ public class TechniqueBook extends Item {
                             if (technique != null) {
                                 PlayerTechniqueAttachments.addPlayerLearnedTechniques(user,technique);
                                 if((PlayerTechniqueAttachments.getPlayerTechniques(user)==null)){
-                                    PlayerTechniqueAttachments.setPlayerTechniques(user, Map.of(Technique.registeredTechniques.get(technique.id()).getSlot(), technique));
+                                    PlayerTechniqueAttachments.setPlayerTechniques(user, Map.of(Technique.registeredTechniques.get(technique.id).getSlot(), technique));
                                 }
-                                else if(PlayerTechniqueAttachments.getTechnique(user, Technique.registeredTechniques.get(technique.id()).getSlot()) == null)
-                                    PlayerTechniqueAttachments.setTechnique(user, Technique.registeredTechniques.get(technique.id()).getSlot(), technique);
+                                else if(PlayerTechniqueAttachments.getTechnique(user, Technique.registeredTechniques.get(technique.id).getSlot()) == null)
+                                    PlayerTechniqueAttachments.setTechnique(user, Technique.registeredTechniques.get(technique.id).getSlot(), technique);
                                 return true;
                             }
                             else {
@@ -49,26 +49,26 @@ public class TechniqueBook extends Item {
         Technique technique = stack.get(CultivationModComponents.BOOK_TECHNIQUE);
         if (technique != null) {
             MutableText nameText = Text.empty();
-            for(String namePart: technique.nameParts()){
+            for(String namePart: technique.nameParts){
                 nameText.append(Text.translatable(namePart));
             }
             tooltip.add(nameText);
-            tooltip.add(Text.translatable(Technique.registeredTechniques.get(technique.id()).getDesc()));
+            tooltip.add(Text.translatable(Technique.registeredTechniques.get(technique.id).getDesc()));
 
             String element;
-            if(Technique.registeredTechniques.get(technique.id()).getAxisElement() != null){
-                element = Technique.registeredTechniques.get(technique.id()).getAxisElement().name();
+            if(Technique.registeredTechniques.get(technique.id).getAxisElement() != null){
+                element = Technique.registeredTechniques.get(technique.id).getAxisElement().name();
             }
-            else if(Technique.registeredTechniques.get(technique.id()).getCompoundElement() != null) {
-                element = Technique.registeredTechniques.get(technique.id()).getCompoundElement().name();
+            else if(Technique.registeredTechniques.get(technique.id).getCompoundElement() != null) {
+                element = Technique.registeredTechniques.get(technique.id).getCompoundElement().name();
             }
             else element = "Qi";
 
             tooltip.add(Text.translatable("cultivation_mod.technique.element", element));
-            tooltip.add(Text.translatable("cultivation_mod.technique.cost", technique.cost()));
-            tooltip.add(Text.translatable("cultivation_mod.technique.stats", technique.power(),technique.range()));
-            for (String modifier : technique.modifiers()){
-                tooltip.add(Text.translatable(Technique.registeredTechniques.get(technique.id()).getModifierDesc(modifier)));
+            tooltip.add(Text.translatable("cultivation_mod.technique.cost", technique.cost));
+            tooltip.add(Text.translatable("cultivation_mod.technique.stats", technique.power,technique.range));
+            for (String modifier : technique.modifiers){
+                tooltip.add(Text.translatable(Technique.registeredTechniques.get(technique.id).getModifierDesc(modifier)));
             }
         }
         else{

--- a/src/main/java/com/cultivation_mod/technique_setup/PlayerTechniqueAttachments.java
+++ b/src/main/java/com/cultivation_mod/technique_setup/PlayerTechniqueAttachments.java
@@ -51,13 +51,13 @@ public class PlayerTechniqueAttachments {
     }
 
     public static int getMastery(AttachmentTarget target, String techniqueKey){
-        return target.getAttached(PLAYER_TECHNIQUES).get(techniqueKey).mastery();
+        return target.getAttached(PLAYER_TECHNIQUES).get(techniqueKey).mastery;
     }
 
     public static void setMastery(AttachmentTarget target, String techniqueKey, int mastery){
         Map<String, Technique> newMap = new HashMap<>(target.getAttached(PLAYER_TECHNIQUES));
         Technique oldTechnique = newMap.get(techniqueKey);
-        Technique newTechnique = new Technique(oldTechnique.id(), oldTechnique.nameParts(), oldTechnique.realm(), mastery, oldTechnique.cost(), oldTechnique.power(), oldTechnique.range(), oldTechnique.modifiers());
+        Technique newTechnique = new Technique(oldTechnique.id, oldTechnique.nameParts, oldTechnique.realm, mastery, oldTechnique.cost, oldTechnique.power, oldTechnique.range, oldTechnique.modifiers);
         newMap.put(techniqueKey,newTechnique);
         target.setAttached(PLAYER_TECHNIQUES,newMap);
     }
@@ -65,7 +65,7 @@ public class PlayerTechniqueAttachments {
 
     //standalone
     public static RegisteredTechnique getRegisteredTechnique(AttachmentTarget target, String techniqueKey){
-        return Technique.registeredTechniques.get(target.getAttached(PLAYER_TECHNIQUES).get(techniqueKey).id());
+        return Technique.registeredTechniques.get(target.getAttached(PLAYER_TECHNIQUES).get(techniqueKey).id);
     }
 
     public static void runTechniqueEffect(AttachmentTarget target, String techniqueKey, String effectType){

--- a/src/main/java/com/cultivation_mod/technique_setup/PlayerTechniqueAttachments.java
+++ b/src/main/java/com/cultivation_mod/technique_setup/PlayerTechniqueAttachments.java
@@ -86,18 +86,20 @@ public class PlayerTechniqueAttachments {
     public static void setPlayerLearnedTechniques(AttachmentTarget target,List<Technique> techniques){
         target.setAttached(PLAYER_LEARNED_TECHNIQUES,techniques);
     }
+
     public static List<Technique> getPlayerLearnedTechniques(AttachmentTarget target, List<Technique> techniques){
         return target.getAttached(PLAYER_LEARNED_TECHNIQUES);
     }
+
     public static void addPlayerLearnedTechniques(AttachmentTarget target,Technique technique){
-        List<Technique> newList = target.getAttached(PLAYER_LEARNED_TECHNIQUES);
-        if(newList!=null)
+        List<Technique> oldList = target.getAttached(PLAYER_LEARNED_TECHNIQUES);
+        List<Technique> newList;
+        if(oldList!=null) {
+            newList = new ArrayList<>(oldList);
             newList.add(technique);
-        else
+        } else
             newList=List.of(technique);
-        target.setAttached(PLAYER_LEARNED_TECHNIQUES,newList);
+        target.setAttached(PLAYER_LEARNED_TECHNIQUES, newList);
     }
-
-
 
 }

--- a/src/main/java/com/cultivation_mod/technique_setup/Technique.java
+++ b/src/main/java/com/cultivation_mod/technique_setup/Technique.java
@@ -14,38 +14,49 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public record Technique(String id, List<String> nameParts, int realm, int mastery, int cost, int power, int range, List<String> modifiers) {
+public class Technique {
+    public final String id;
+    public final List<String> nameParts;
+    public final int realm;
+    public final int mastery;
+    public final int cost;
+    public final int power;
+    public final int range;
+    public final List<String> modifiers;
+
+    public Technique(String id, List<String> nameParts, int realm, int mastery, int cost, int power, int range, List<String> modifiers) {
+        this.id = id;
+        this.nameParts = nameParts;
+        this.realm = realm;
+        this.mastery = mastery;
+        this.cost = cost;
+        this.power = power;
+        this.range = range;
+        this.modifiers = modifiers;
+    }
 
     public static Map<String,RegisteredTechnique> registeredTechniques = new HashMap<>();
 
     public static final Codec<Technique> TECHNIQUE_CODEC = RecordCodecBuilder.create(i -> i.group(
-            Codec.STRING.fieldOf("id").forGetter(Technique::id),
-            Codec.STRING.listOf().fieldOf("nameParts").forGetter(Technique::nameParts),
-            Codec.INT.fieldOf("realm").forGetter(Technique::realm),
-            Codec.INT.fieldOf("mastery").forGetter(Technique::mastery),
-            Codec.INT.fieldOf("cost").forGetter(Technique::cost),
-            Codec.INT.fieldOf("power").forGetter(Technique::power),
-            Codec.INT.fieldOf("range").forGetter(Technique::range),
-            Codec.STRING.listOf().fieldOf("modifiers").forGetter(Technique::modifiers)
+            Codec.STRING.fieldOf("id").forGetter((technique) -> technique.id),
+            Codec.STRING.listOf().fieldOf("nameParts").forGetter((technique) -> technique.nameParts),
+            Codec.INT.fieldOf("realm").forGetter((technique) -> technique.realm),
+            Codec.INT.fieldOf("mastery").forGetter((technique) -> technique.mastery),
+            Codec.INT.fieldOf("cost").forGetter((technique) -> technique.cost),
+            Codec.INT.fieldOf("power").forGetter((technique) -> technique.power),
+            Codec.INT.fieldOf("range").forGetter((technique) -> technique.range),
+            Codec.STRING.listOf().fieldOf("modifiers").forGetter((technique) -> technique.modifiers)
     ).apply(i, Technique::new));
 
     public static final PacketCodec<ByteBuf, Technique> TECHNIQUE_PACKET_CODEC = PacketCodec.tuple(
-            PacketCodecs.STRING,
-            Technique::id,
-            PacketCodecs.STRING.collect(PacketCodecs.toList()),
-            Technique::nameParts,
-            PacketCodecs.INTEGER,
-            Technique::realm,
-            PacketCodecs.INTEGER,
-            Technique::mastery,
-            PacketCodecs.INTEGER,
-            Technique::cost,
-            PacketCodecs.INTEGER,
-            Technique::power,
-            PacketCodecs.INTEGER,
-            Technique::range,
-            PacketCodecs.STRING.collect(PacketCodecs.toList()),
-            Technique::modifiers,
+            PacketCodecs.STRING, (technique) -> technique.id,
+            PacketCodecs.STRING.collect(PacketCodecs.toList()), (technique) -> technique.nameParts,
+            PacketCodecs.INTEGER, (technique) -> technique.realm,
+            PacketCodecs.INTEGER, (technique) -> technique.mastery,
+            PacketCodecs.INTEGER, (technique) -> technique.cost,
+            PacketCodecs.INTEGER, (technique) -> technique.power,
+            PacketCodecs.INTEGER, (technique) -> technique.range,
+            PacketCodecs.STRING.collect(PacketCodecs.toList()), (technique) -> technique.modifiers,
             Technique::new);
 
     public void activeEffect(PlayerEntity player) {


### PR DESCRIPTION
Does exactly what it says in the name; `Technique.java` is now no longer a record even if it behaves like one.

It has a constructor and all of the parameters, we just now use lambdas instead of the inbuilt method references for records, and everything there works just fine.